### PR TITLE
Fixed some more tester errors and removed un used imports

### DIFF
--- a/backend/src/main/java/com/pistachio/restservice/main/LootBoxController.java
+++ b/backend/src/main/java/com/pistachio/restservice/main/LootBoxController.java
@@ -4,8 +4,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
-import com.pistachio.restservice.Pistachio;
-
 import java.util.List;
 
 @RestController

--- a/backend/src/main/java/com/pistachio/restservice/main/Player.java
+++ b/backend/src/main/java/com/pistachio/restservice/main/Player.java
@@ -158,8 +158,8 @@ public class Player {
 		this.battleID = battle;
 	}
 
-	public void setBattle(Battle b) {
-		this.battleID = b.getId();
+	public void setBattle(String b) {
+		this.battleID = b;
 	}
 
 	public void setTeam(List<String> team) {

--- a/backend/src/test/java/com/pistachio/main/test/BattleTest.java
+++ b/backend/src/test/java/com/pistachio/main/test/BattleTest.java
@@ -22,15 +22,15 @@ class BattleTest {
 		Battle B2 = new Battle("123", "Juan", new ArrayList<Monster>(), "pepito", new ArrayList<Monster>());
 		Battle B3 = new Battle("456", "Juan", new ArrayList<Monster>(), "pepito", new ArrayList<Monster>());
 		
-	// 	assertTrue(B1.equals(B2));
-	// 	assertFalse(B1.equals(B3));
-	// }
+		assertTrue(B1.equals(B2));
+		assertFalse(B1.equals(B3));
+	}
 
 	@Test
 	void ActionsTest() {
 		//Battle B1 = new Battle("123", "Juan", new ArrayList<Monster>(), "pepito", new ArrayList<Monster>());
-		//B1.addAction("Help");
-		//assertTrue(B1.getActionLog().contains("Help"));
+		// B1.addAction("Help");
+		// assertTrue(B1.getActionLog().contains("Help"));
 	}
 	
 }

--- a/backend/src/test/java/com/pistachio/main/test/LootBoxTest.java
+++ b/backend/src/test/java/com/pistachio/main/test/LootBoxTest.java
@@ -9,9 +9,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import com.pistachio.restservice.main.LootBox;
-import com.pistachio.restservice.main.Monster;
-import com.pistachio.restservice.main.Move;
-import com.pistachio.restservice.main.Stats;
 
 class LootBoxTest {
 


### PR DESCRIPTION
A method in the player was still taking battle as a parameter instead of a string. Removed un used imports on a class. Un-commented a simple test for adding that was still commented for whatever reason.